### PR TITLE
Fix judger docker dns

### DIFF
--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -42,3 +42,5 @@ services:
       - RUST_LOG=DEBUG
     volumes:
       - ../environment/rclone-minio.conf:/workspace/data/rclone-minio.conf
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Close #37 , `host.docker.internal` is only available in docker desktop.

Extra host need be added to resolve this url.
