### PR TITLE
feat: default submission sort by time & fix: go test cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: gen-proto
 
 .PHONY: test
 test: gen-swagger check setup-db
-	go test -cover -v ./...
+	go test -cover -v -count=1 ./...
 
 .PHONY: run-schedule
 run-schedule: build check

--- a/src/application/server/handler/submission.go
+++ b/src/application/server/handler/submission.go
@@ -77,8 +77,9 @@ func getSubmissionList(ginCtx *gin.Context) {
 	}
 
 	options := mapper.GetSubmissionOptions{
-		Limit:  &limit,
-		Offset: &offset,
+		Limit:          &limit,
+		Offset:         &offset,
+		OrderByColumns: []model.OrderByColumnOption{{Column: "create_at", Desc: true}},
 	}
 
 	submissions, total, svcErr := service.GetJudgeTaskSubmissionList(ginCtx, options)


### PR DESCRIPTION
Sometimes `go test` will not insert data in minio due to its cache.

Use `-count=1` force it to run one time.