### PR TITLE
feat: change application name read_pkg to problem_package_loader && remove duplicate code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build: gen-swagger gen-proto
 	go build -o artifacts/bin/init_db src/application/init_db/main.go
 	go build -o artifacts/bin/service src/application/server/main.go
 	go build -o artifacts/bin/schedule src/application/schedule/main.go
-	go build -o artifacts/bin/read_pkg src/application/read_pkg/main.go
+	go build -o artifacts/bin/problem_package_loader src/application/problem_package_loader/main.go
 
 .PHONY: build-image
 build-image:
@@ -54,7 +54,7 @@ test: gen-swagger check setup-db
 
 .PHONY: pkg
 pkg: setup-db
-	./artifacts/bin/read_pkg
+	./artifacts/bin/problem_package_loader
 
 .PHONY: run-schedule
 run-schedule: build check

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	gorm.io/gorm v1.25.4
 )
 
-require github.com/swaggo/swag v1.16.3 // indirect
+require github.com/swaggo/swag v1.16.3
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/src/application/problem_package_loader/main.go
+++ b/src/application/problem_package_loader/main.go
@@ -25,20 +25,6 @@ func main() {
 	minioClient := minioAgent.GetMinioClient()
 
 	log.Printf("%#v\n", minioClient) // minioClient is now set up
-	bucketName := minioAgent.GetBucketName()
-
-	err := minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
-	if err != nil {
-		// Check to see if we already own this bucket (which happens if you run this twice)
-		exists, errBucketExists := minioClient.BucketExists(ctx, bucketName)
-		if errBucketExists == nil && exists {
-			log.Printf("We already own %s\n", bucketName)
-		} else {
-			log.Fatalln(err)
-		}
-	} else {
-		log.Printf("Successfully created %s\n", bucketName)
-	}
 
 	// Read package files
 	// Search Problem under packagePath
@@ -46,9 +32,11 @@ func main() {
 	//    parse problem.yaml's name as `title`,
 	//    parse problem.md as description.
 	// 2. insert object into minio storage.
-	packagePath := "tests/data/packages/icpc"
-	title := ""
-	slug := ""
+	var (
+		packagePath string = "tests/data/packages/icpc"
+		title       string
+		slug        string
+	)
 	filepath.Walk(packagePath, func(path string, info fs.FileInfo, err error) error {
 		if info == nil {
 			return fmt.Errorf("file info is nil")
@@ -93,7 +81,7 @@ func main() {
 			})
 		}
 
-		_, minioErr := minioClient.FPutObject(ctx, bucketName,
+		_, minioErr := minioClient.FPutObject(ctx, minioAgent.GetBucketName(),
 			relativePath,
 			path,
 			minio.PutObjectOptions{})


### PR DESCRIPTION
1. Change the application name from `read_pkg` to `problem_package_loader`
2. Remove duplicate code in problem_package_loader/main.go L28-L41. The logic of MakeBucket is already implemented in minioAgent.GetMinioClient().