### PR TITLE
resolve #97  &&  log format with config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,18 @@ unset-dependencies:
 	docker compose stop postgres redis minio clickhouse
 	docker compose rm -f postgres redis minio clickhouse
 
+.PHONY: unset-data
+unset-data: build
+	./bin/clean
+
 .PHONY: setup-dependencies
-setup-dependencies: unset-dependencies build get-front get-problem-packages
+setup-dependencies: build get-front get-problem-packages
 	docker compose up -d postgres redis minio clickhouse
-	@echo "Wait 10 seconds for db setup"
-	sleep 10s
+	@echo "Wait 2 seconds for db setup"
+	sleep 2s
+
+.PHONY: setup-data
+setup-data:setup-dependencies unset-data
 	./bin/init
 
 .PHONY: get-front

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ check: gen-proto install-cilint
 	golangci-lint run
 
 .PHONY: test
-test: build gen-swagger setup-dependencies
+test: build gen-swagger setup-data
 	go test -race -covermode=atomic -coverprofile=coverage.out -cover -v -count=1 \
 		./models/... ./modules/... ./services/...
 

--- a/cmd/clean/main.go
+++ b/cmd/clean/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+
+	"github.com/minio/minio-go/v7"
+	casbin_agent "github.com/oj-lab/oj-lab-platform/modules/agent/casbin"
+
+	judge_model "github.com/oj-lab/oj-lab-platform/models/judge"
+	problem_model "github.com/oj-lab/oj-lab-platform/models/problem"
+	user_model "github.com/oj-lab/oj-lab-platform/models/user"
+	gorm_agent "github.com/oj-lab/oj-lab-platform/modules/agent/gorm"
+	minio_agent "github.com/oj-lab/oj-lab-platform/modules/agent/minio"
+
+	log_module "github.com/oj-lab/oj-lab-platform/modules/log"
+)
+
+func clearCasbin() {
+	enforcer := casbin_agent.GetDefaultCasbinEnforcer()
+	enforcer.ClearPolicy() // no err return
+	log_module.AppLogger().Info("Clear Casbin success")
+}
+
+func removeMinioObjects() {
+	minioClient := minio_agent.GetMinioClient()
+	objectsCh := make(chan minio.ObjectInfo)
+
+	go func() {
+		defer close(objectsCh)
+		opts := minio.ListObjectsOptions{Recursive: true}
+		for object := range minioClient.ListObjects(context.Background(), minio_agent.GetBucketName(), opts) {
+			if object.Err != nil {
+				log_module.AppLogger().WithError(object.Err).Error("Get object error")
+			}
+			objectsCh <- object
+		}
+	}()
+
+	errorCh := minioClient.RemoveObjects(context.Background(), minio_agent.GetBucketName(), objectsCh, minio.RemoveObjectsOptions{})
+	for e := range errorCh {
+		log_module.AppLogger().WithError(e.Err).Error("Failed to remove " + e.ObjectName)
+	}
+
+	log_module.AppLogger().Info("Remove Minio Objects success")
+}
+
+func clearDB() {
+	db := gorm_agent.GetDefaultDB()
+
+	err := db.Migrator().DropTable(
+		&user_model.User{},
+		&problem_model.Problem{},
+		&problem_model.AlgorithmTag{},
+		&judge_model.Judge{},
+		&judge_model.JudgeResult{},
+		"problem_algorithm_tags",
+		"casbin_rule",
+	)
+
+	if err != nil {
+		panic("failed to drop tables")
+	}
+
+	log_module.AppLogger().Info("Clear db success")
+
+}
+func main() {
+	removeMinioObjects()
+	clearCasbin()
+	clearDB()
+
+	println("data clean success")
+}

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [log]
 level = "debug"
-force_quote = true
+pretty_json = true
 time_on = true
 time_format = "2006-01-02 15:04:05"
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,8 @@
 [log]
 level = "debug"
+force_quote = true
+time_on = true
+time_format = "2006-01-02 15:04:05"
 
 [database]
 dsn = "user=postgres password=postgres host=localhost port=5432 dbname=oj_lab sslmode=disable TimeZone=Asia/Shanghai"

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -10,7 +10,7 @@ import (
 )
 
 const logLevelProp = "log.level"
-const logForceQuote = "log.force_quote"
+const logPrettyJson = "log.pretty_json"
 const logTimeOn = "log.time_on"
 const logTimeFormat = "log.time_format"
 
@@ -31,8 +31,8 @@ func setupLog() {
 
 	logrus.SetLevel(logrus.DebugLevel)
 	lvl := config_module.AppConfig().GetString(logLevelProp)
-	forceQuote := config_module.AppConfig().GetBool(logForceQuote)
-	fullTimeOn := config_module.AppConfig().GetBool(logTimeOn)
+	prettyJson := config_module.AppConfig().GetBool(logPrettyJson)
+	timeOn := config_module.AppConfig().GetBool(logTimeOn)
 	timestampFormat := config_module.AppConfig().GetString(logTimeFormat)
 
 	logLevel, err := logrus.ParseLevel(lvl)
@@ -41,11 +41,10 @@ func setupLog() {
 		logrus.SetLevel(logLevel)
 	}
 	// TODO: control log format in config
-	// logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetFormatter(&logrus.TextFormatter{
-		ForceQuote:      forceQuote, // value Quote
-		FullTimestamp:   fullTimeOn,
-		TimestampFormat: timestampFormat,
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat:  timestampFormat,
+		DisableTimestamp: !timeOn,
+		PrettyPrint:      prettyJson,
 	})
 }
 

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -3,12 +3,16 @@ package log_module
 import (
 	"os"
 	"runtime"
+	"strconv"
 
 	config_module "github.com/oj-lab/oj-lab-platform/modules/config"
 	"github.com/sirupsen/logrus"
 )
 
 const logLevelProp = "log.level"
+const logForceQuote = "log.force_quote"
+const logTimeOn = "log.time_on"
+const logTimeFormat = "log.time_format"
 
 func AppLogger() *logrus.Entry {
 	return logrus.WithFields(logrus.Fields{
@@ -16,7 +20,8 @@ func AppLogger() *logrus.Entry {
 			pc := make([]uintptr, 1)
 			runtime.Callers(3, pc)
 			f := runtime.FuncForPC(pc[0])
-			return f.Name()
+			name, line := f.FileLine(pc[0])
+			return name + ":" + strconv.Itoa(line)
 		}(),
 	})
 }
@@ -26,6 +31,10 @@ func setupLog() {
 
 	logrus.SetLevel(logrus.DebugLevel)
 	lvl := config_module.AppConfig().GetString(logLevelProp)
+	forceQuote := config_module.AppConfig().GetBool(logForceQuote)
+	fullTimeOn := config_module.AppConfig().GetBool(logTimeOn)
+	timestampFormat := config_module.AppConfig().GetString(logTimeFormat)
+
 	logLevel, err := logrus.ParseLevel(lvl)
 	if err == nil {
 		println("log level:", lvl)
@@ -33,6 +42,11 @@ func setupLog() {
 	}
 	// TODO: control log format in config
 	// logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetFormatter(&logrus.TextFormatter{
+		ForceQuote:      forceQuote, // value Quote
+		FullTimestamp:   fullTimeOn,
+		TimestampFormat: timestampFormat,
+	})
 }
 
 func init() {


### PR DESCRIPTION
1. data clean script which desire to be a reverse effect of `init`.  The Makefile may be refined.

2. A logger format which can be control in config.toml

Current logger like, which we can easily locate in vscode.
```
INFO[2024-08-06 00:10:22] Remove Minio Objects success                  caller="/home/zztrans/src/ojlab/oj-lab-platform/cmd/clean/main.go:44"
INFO[2024-08-06 00:10:22] Casbin enforcer watcher initialized           caller="/home/zztrans/src/ojlab/oj-lab-platform/modules/agent/casbin/enforcer.go:56"
```